### PR TITLE
Implements command line arguments for specifying output files.

### DIFF
--- a/src/MarieAssembler.c
+++ b/src/MarieAssembler.c
@@ -451,25 +451,7 @@ int Assemble(file_state *File, paged_list *IdentifierDestinationList, paged_list
 	return !DidErrorOccur;
 }
 
-// String should be a null terminated 
-int IndexOfFromEnd(wchar_t *String, wchar_t Target) {
-	int Result = 0;
-
-	while(String[Result] != L'\0') { Result++; }
-	Result--;
-	
-	for(; String[Result] != L'\0'; Result--) {
-		if (String[Result] == Target) { return Result; }
-	}
-	return -1;
-}
-
-void OutputLogisimImage(wchar_t *FileName) {
-	FILE *FileStream = Platform_WideFOpen(FileName, L"w");
-	if (!FileStream) {
-		wprintf(L"[Error Output] Could not open file \"%s\" for output.\n", FileName);
-	}
-	
+int OutputLogisimImage(FILE *FileStream) {
 	fprintf(FileStream, "v2.0 raw\r\n");
 
 	int Consectuive = 0;
@@ -492,18 +474,20 @@ void OutputLogisimImage(wchar_t *FileName) {
 	}
 
 	fclose(FileStream);
+
+	return TRUE; // @TODO @NoMerge
 }
 
-void OutputRawHex(wchar_t *FileName) {
-	FILE *FileStream = Platform_WideFOpen(FileName, L"w");
-
+int OutputRawHex(FILE *FileStream) {
 	fwrite(Program, sizeof(Program), 1, FileStream);
 	
 	fclose(FileStream);
+
+	return TRUE; // @TODO @NoMerge
 }
 
-void OutputSymbolTable(wchar_t *FileName, paged_list *IdentifierDestinationList, paged_list *IdentifierSourceList) {
-	FILE *FileStream = Platform_WideFOpen(FileName, L"w,ccs=UNICODE");
+int OutputSymbolTable(FILE *FileStream, paged_list *IdentifierDestinationList, paged_list *IdentifierSourceList) {
+	//FILE *FileStream = Platform_WideFOpen(FileName, L"w,ccs=UNICODE");
 
 	int IdentifierMaxLength = 0;
 	for (int Index = 0; ; Index++) {
@@ -535,10 +519,12 @@ void OutputSymbolTable(wchar_t *FileName, paged_list *IdentifierDestinationList,
 		fwprintf(FileStream, L"\n");
 	}
 	fclose(FileStream);
+
+	return TRUE; // @TODO @NoMerge
 }
 
-void OutputListing(wchar_t *FileName, paged_list *IdentifierDestinationList, paged_list *IdentifierSourceList) {
-	FILE *FileStream = Platform_WideFOpen(FileName, L"w,ccs=UNICODE");
+int OutputListing(FILE *FileStream, paged_list *IdentifierDestinationList, paged_list *IdentifierSourceList) {
+	//FILE *FileStream = Platform_WideFOpen(FileName, L"w,ccs=UNICODE");
 	int InMemoryGap = FALSE;
 
 	// @TODO make this growable!!! Someone someday will be really mad at me for limiting the size of this string.
@@ -867,14 +853,14 @@ void OutputListing(wchar_t *FileName, paged_list *IdentifierDestinationList, pag
 	}
 	
 	fclose(FileStream);
+
+	return TRUE; // @TODO @NoMerge
 }
 
-wchar_t *LoadFileIntoMemory(wchar_t *FileName, int *Success) {
+wchar_t *LoadFileIntoMemory(FILE* FileStream, int FileSize, int *Success) {
 	wchar_t *Result = 0;
-	size_t FileSize = Platform_GetFileSize(FileName, Success);
 
 	if (*Success) {
-		FILE *FileStream = Platform_WideFOpen(FileName, L"rb");	
 		uint8_t ByteOrderMark[4];
 		fread(&ByteOrderMark, sizeof(uint8_t), Min(4, FileSize), FileStream);
 		fseek(FileStream, 0, SEEK_SET);
@@ -1010,66 +996,51 @@ wchar_t *LoadFileIntoMemory(wchar_t *FileName, int *Success) {
 	return Result;
 }
 
-int ApplicationMain(int ArgCount, wchar_t **Args) {
-	if (!(ArgCount == 2 || ArgCount == 3)) {
-		const wchar_t *HelpMessage = 
-			L"* Usage: %s <Path To Source> [Output File Name]\n"
-			"* This program compiles Marie Assembly code into logisim rom images.\n"
-			"* <Path To Source> is the path to the assembly code you'd like to assemble.\n"
-			"* [Output File Name] is the name of the files that this program will emit.\n"
-			"** If [Output File Name] is not provied, then this program generates [Output File Name] in the form of OUT_<File Name>.\n"
-			"* For Every compliation:\n"
-			"** A Raw Image file will be emitted as [Output File Name].hex\n"
-			"** A listing file will be emitted as [Output File Name].lst\n"
-			"** A symbol table will be output as [Output File Name].sym\n"
-			"** A logisim image file will bit output as [Output File Name].LogisimImage\n";
-		wprintf(HelpMessage, Args[0]);
-		return 0;
+int ApplicationMain(FILE *InFile, int InFileSize, FILE *OutLogisim, FILE *OutRawHex, FILE *OutSymbolTable, FILE *OutListing) {
+	int Success = TRUE;
+	if (InFile == 0) {
+		Success = FALSE;
+		printf("A input file was not provided!\n");
 	}
 
-	int Success = TRUE;
+	if (Success) {
+		file_state FileState = {
+			.Line = 1,
+			.Column = 0,
+		};
+		FileState.At = LoadFileIntoMemory(InFile, InFileSize, &Success);
 
-	file_state FileState = {
-		.Line = 1,
-		.Column = 0,
-	};
-	FileState.At = LoadFileIntoMemory(Args[1], &Success);
-	if (Success == FALSE) { return 0; }
-
-	paged_list *IdentifierDestinationList = AllocatePagedList(sizeof(identifier_dest), 10);
-	paged_list *IdentifierSourceList = AllocatePagedList(sizeof(identifier_source), 10);
-	
-	if (Assemble(&FileState, IdentifierDestinationList, IdentifierSourceList)) {
-		wchar_t *OutputFileName;
-		int OutputNameLength;
-
-		if (ArgCount == 2) {
-			OutputFileName = Platform_CreateOutputFileName(Args[1], &Success);
-		}
-		else {
-			OutputFileName = Args[2];
-		}
-
-		OutputNameLength = wcslen(OutputFileName) + 1;
-	
-		int Size = OutputNameLength;
+		paged_list *IdentifierDestinationList = AllocatePagedList(sizeof(identifier_dest), 10);
+		paged_list *IdentifierSourceList = AllocatePagedList(sizeof(identifier_source), 10);
 		
-		wchar_t *OutputLogisimImageName = calloc(sizeof(wchar_t), Size + 13);
-		wchar_t *OutputRawHexName = calloc(sizeof(wchar_t), Size + 4);
-		wchar_t *OutputSymbolTableName = calloc(sizeof(wchar_t), Size + 4);
-		wchar_t *OutputListingName = calloc(sizeof(wchar_t), Size + 4);
+		Success = Assemble(&FileState, IdentifierDestinationList, IdentifierSourceList);
+		
+		if (Success) {
+			if ((OutLogisim == 0) && (OutRawHex == 0) && (OutSymbolTable == 0) && (OutListing == 0)) {
+				Success = FALSE;
+				printf("Warning: No outputs were were requested. No output files are being generated.\n");
+			}
 
-		_snwprintf(OutputLogisimImageName, Size + 13, L"%.*s.LogisimImage", OutputNameLength + 4, OutputFileName);
-		_snwprintf(OutputRawHexName, Size + 4, L"%.*s.hex", OutputNameLength + 4, OutputFileName);	
-		_snwprintf(OutputSymbolTableName, Size + 4, L"%.*s.sym", OutputNameLength + 4, OutputFileName);
-		_snwprintf(OutputListingName, Size + 4, L"%.*s.lst", OutputNameLength + 4, OutputFileName);
-
-		OutputRawHex(OutputRawHexName);
-		OutputLogisimImage(OutputLogisimImageName);
-		OutputSymbolTable(OutputSymbolTableName, IdentifierDestinationList, IdentifierSourceList);
-		OutputListing(OutputListingName, IdentifierDestinationList, IdentifierSourceList);
+			if (OutRawHex != 0) {
+				int Temp = OutputRawHex(OutRawHex);
+				Success = Success ? Temp : FALSE; // only take on the new output value 
+			}
+			if (OutLogisim != 0) {
+				int Temp = OutputLogisimImage(OutLogisim);
+				Success = Success ? Temp : FALSE;
+			}
+			if (OutSymbolTable != 0) {
+				int Temp = OutputSymbolTable(OutSymbolTable, IdentifierDestinationList, IdentifierSourceList);
+				Success = Success ? Temp : FALSE;
+			}
+			if (OutListing != 0) {
+				int Temp = OutputListing(OutListing, IdentifierDestinationList, IdentifierSourceList);
+				Success = Success ? Temp : FALSE;
+			}
+			
+		}
 	}
 
 	// @TODO output a value that repersents our success.
-	return 0;
+	return Success;
 }

--- a/src/Platform_MarieAssembler.h
+++ b/src/Platform_MarieAssembler.h
@@ -61,18 +61,6 @@
  */
 size_t Platform_GetFileSize(wchar_t* FileName, int* Success);
 
-/* Auto generates the output file name based on the input file name.
- * This is platform spefic because different platforms have different file path conventions.
- * @Param Path input file path
- * @Param Arena Memory Arena
- * @Param Indicates if this function was successful.
- * Example:
- *  Path = L"C:\Foo\Bar\Test.MarieAsm"
- *  Result = L"C:\Foo\Bar\OUT_Test"
- */
-wchar_t *Platform_CreateOutputFileName(wchar_t *Path, int *Success);
-
-FILE *Platform_WideFOpen(wchar_t *Path, wchar_t *Mode);
 void Platform_Breakpoint();
 
 //-----
@@ -80,9 +68,12 @@ void Platform_Breakpoint();
 
 /* "Main" function for the application
  * While the application's actual entry point is in the platform spefic file, ApplicationMain() actually runs the application.
- * @Params ArgCount The Amount of stings in Args
- * @Params Args A list of strings that contain the arguments to this application.
+ * @Params InFile  Handle to the input file
+ * @Params LogisimOut  Handle where a Logisim rom file should be writen to
+ * @Params RawHexOut  Handle where file containing a raw hex output should be writen to
+ * @Params SymbolTableOut  Handle where a symbol table should be writen to
+ * @Params ListingOut  Handle where a assembly listing should be writen to
  */
-int ApplicationMain(int ArgCount, wchar_t **Args);
+int ApplicationMain(FILE *InFile, int InFileSize, FILE *OutLogisim, FILE *OutRawHex, FILE *OutSymbolTable, FILE *OutListing);
 
 #endif

--- a/src/win32_MarieAssembler.c
+++ b/src/win32_MarieAssembler.c
@@ -63,6 +63,23 @@ int StartsWith(wchar_t *String, wchar_t *Target) {
 	return Result;
 }
 
+wchar_t* GenerateOutputPath(wchar_t *InFileName, wchar_t *PostFix) {
+	int DotIndex = IndexOfFromEnd(InFileName, L'.');
+	int PathSeperatorIndex = Max(IndexOfFromEnd(InFileName, L'\\'), IndexOfFromEnd(InFileName, L'/'));
+	if (DotIndex < PathSeperatorIndex || DotIndex == -1) {
+		// The dot we found was part of the file path.
+		// Or we didn't find a dot.
+		DotIndex = wcslen(InFileName);
+	}
+	
+	int AutoFileNameLength = DotIndex + wcslen(PostFix) + 1;
+	wchar_t *AutoFileName = calloc(AutoFileNameLength, sizeof(wchar_t));
+	
+	_snwprintf(AutoFileName, AutoFileNameLength, L"%.*s%s", DotIndex, InFileName, PostFix);
+
+	return AutoFileName;
+}
+
 const char* HelpMessage =
 	"Usage: MarieAssembler <InFileName> [Output Options]\n"
 	"Where [Output Options] can be any combination of:\n"
@@ -211,12 +228,7 @@ int wmain(int ArgCount, wchar_t **Args, wchar_t **Env) {
 	}
 
 	if (GenLogisim) {
-		// @TODO this block could be pulled out into a function.
-		int DotIndex = IndexOfFromEnd(InFileName, L'.');
-		int AutoFileNameLength = DotIndex + wcslen(L".LogisimImage") + 1;
-		wchar_t *AutoFileName = calloc(AutoFileNameLength, sizeof(wchar_t));
-		_snwprintf(AutoFileName, AutoFileNameLength, L"%.*s.LogisimImage", DotIndex, InFileName);
-
+		wchar_t *AutoFileName = GenerateOutputPath(InFileName, L".LogisimImage");
 		OutLogisim = _wfopen(AutoFileName, L"w");
 		if (OutLogisim == 0) {
 			wprintf(L"I could not open the Logisim output file's auto-generated path \"%s\" for writing!\n", AutoFileName);
@@ -225,11 +237,7 @@ int wmain(int ArgCount, wchar_t **Args, wchar_t **Env) {
 		free(AutoFileName);
 	}
 	if (GenHex) {
-		int DotIndex = IndexOfFromEnd(InFileName, L'.');
-		int AutoFileNameLength = DotIndex + wcslen(L".hex") + 1;
-		wchar_t *AutoFileName = calloc(AutoFileNameLength, sizeof(wchar_t));
-		_snwprintf(AutoFileName, AutoFileNameLength, L"%.*s.hex", DotIndex, InFileName);
-
+		wchar_t *AutoFileName = GenerateOutputPath(InFileName, L".hex");
 		OutHex = _wfopen(AutoFileName, L"wb");
 		if (OutLogisim == 0) {
 			wprintf(L"I could not open the raw hex output file's auto-generated path \"%s\" for writing!\n", AutoFileName);
@@ -238,11 +246,7 @@ int wmain(int ArgCount, wchar_t **Args, wchar_t **Env) {
 		free(AutoFileName);
 	}
 	if (GenListing) {
-		int DotIndex = IndexOfFromEnd(InFileName, L'.');
-		int AutoFileNameLength = DotIndex + wcslen(L".lst") + 1;
-		wchar_t *AutoFileName = calloc(AutoFileNameLength, sizeof(wchar_t));
-		_snwprintf(AutoFileName, AutoFileNameLength, L"%.*s.lst", DotIndex, InFileName);
-
+		wchar_t *AutoFileName = GenerateOutputPath(InFileName, L".lst");
 		OutListing = _wfopen(AutoFileName, L"w,ccs=UNICODE");
 		if (OutLogisim == 0) {
 			wprintf(L"I could not open the listing output file's auto-generated path \"%s\" for writing!\n", AutoFileName);
@@ -251,11 +255,7 @@ int wmain(int ArgCount, wchar_t **Args, wchar_t **Env) {
 		free(AutoFileName);
 	}
 	if (GenSymbolTable) {
-		int DotIndex = IndexOfFromEnd(InFileName, L'.');
-		int AutoFileNameLength = DotIndex + wcslen(L".sym") + 1;
-		wchar_t *AutoFileName = calloc(AutoFileNameLength, sizeof(wchar_t));
-		_snwprintf(AutoFileName, AutoFileNameLength, L"%.*s.sym", DotIndex, InFileName);
-
+		wchar_t *AutoFileName = GenerateOutputPath(InFileName, L".sym");
 		OutSymbolTable = _wfopen(AutoFileName, L"w,ccs=UNICODE");
 		if (OutLogisim == 0) {
 			wprintf(L"I could not open the Logisim output file's auto-generated path \"%s\" for writing!\n", AutoFileName);

--- a/src/win32_MarieAssembler.c
+++ b/src/win32_MarieAssembler.c
@@ -38,33 +38,238 @@ size_t Platform_GetFileSize(wchar_t *FileName, int *Success) {
 	return (size_t)Result.QuadPart;
 }
 
-FILE *Platform_WideFOpen(wchar_t *Path, wchar_t *Mode) {
-	return _wfopen(Path, Mode);
+int IndexOfFromEnd(wchar_t *String, wchar_t Target) {
+	int Result = 0;
+
+	while(String[Result] != L'\0') { Result++; }
+	Result--;
+	
+	for(; String[Result] != L'\0'; Result--) {
+		if (String[Result] == Target) { return Result; }
+	}
+	return -1;
 }
 
-wchar_t *Platform_CreateOutputFileName(wchar_t *Path, int *Success) {
-	wchar_t *Result = 0;
-
-	wchar_t *StartOfFileName = PathFindFileName(Path);
-	int OutputNameLength = IndexOfFromEnd(StartOfFileName, L'.');
-
-	int PathLength = 0;
-	for(int Index = 0; Path[Index] != L'\0'; Index++) {
-		if (Path[Index] == L'\\' ||
-		    Path[Index] == L'/') { // @TODO I'm not totally sure if this is kosher on windows.
-			PathLength = Index + 1;
+int StartsWith(wchar_t *String, wchar_t *Target) {
+	int Result = FALSE;
+	int Length = wcslen(Target);
+	if (Length <= wcslen(String)) {
+		for (int Index = 0; Index <= Length; Index++) {
+			if (Index == Length) { Result = TRUE; break; }
+			if (String[Index] != Target[Index]) { break; }
 		}
 	}
 
-	if (*Success) {
-		Result = calloc(PathLength + OutputNameLength + wcslen(L"OUT_") + 1, sizeof(wchar_t));
-		_snwprintf(Result, PathLength + OutputNameLength + wcslen(L"OUT_") + 1, L"%.*sOUT_%.*s", PathLength, Path, OutputNameLength, StartOfFileName);
-	}
-
-	if (!Result) { *Success = FALSE; }
 	return Result;
 }
 
+const char* HelpMessage =
+	"Usage: MarieAssembler <InFileName> [Output Options]\n"
+	"Where [Output Options] can be any combination of:\n"
+	"  --logisim [FileName] ==> Outputs Logisim rom image at [FileName], or if blank <InFileName>.LogisimImage\n"
+	"  --rawhex [FileName] ==> Outputs a file containing the raw hex for the program at [FileName], or if blank <InFileName>.hex\n"
+	"  --symboltable [FileName] ==> Outputs a file containing a symbol table for the program at [FileName], or if blank <InFileName>.sym\n"
+	"  --listing [FileName] ==> Outputs a file containing a listing for the program at [FileName], or if blank <InFileName>.lst\n";
+
 int wmain(int ArgCount, wchar_t **Args, wchar_t **Env) {
-	return ApplicationMain(ArgCount, Args);
+	FILE *InFile = 0, *OutLogisim = 0, *OutHex = 0, *OutSymbolTable = 0, *OutListing = 0;
+	int GenLogisim = FALSE, GenHex = FALSE, GenSymbolTable = FALSE, GenListing = FALSE;
+	wchar_t *InFileName = 0;
+	uint64_t InFileSize = 0;
+	int Success = TRUE;
+
+	if (ArgCount == 1) {
+		printf(HelpMessage);
+		Success = FALSE;
+	}
+	
+	for (int Index = 1; Index < ArgCount;) {
+		wchar_t * Arg = Args[Index];
+		
+		if (StartsWith(Arg, L"--logisim")) {
+			if (Index + 1 >= ArgCount) { Arg = L""; }
+			else { Arg = Args[Index + 1]; }
+
+			if (OutLogisim == 0 && GenLogisim == FALSE) {
+				if (!((StartsWith(Arg, L"--")) || (Arg[0] == 0))) {
+					Index++;
+					OutLogisim = _wfopen(Arg, L"w");
+					if (OutLogisim == 0) {
+						wprintf(L"I could not open the Logisim output file \"%s\" for writing!\n", Arg);
+						Success = FALSE;
+						break;
+					}
+				}
+				else {
+					GenLogisim = TRUE;
+				}
+			}
+			else {
+				wprintf(L"Option --logisim was provided twice!\n");
+				Success = FALSE;
+				break;
+			}
+		}
+		else if (StartsWith(Arg, L"--rawhex")) {
+			if (Index + 1 >= ArgCount) { Arg = L""; }
+			else { Arg = Args[Index + 1]; }
+
+			if (OutHex == 0 && GenHex == FALSE) {
+				if (!((StartsWith(Arg, L"--")) || (Arg[0] == 0))) {
+					Index++;
+					OutHex = _wfopen(Arg, L"wb");
+					if (OutHex == 0) {
+						wprintf(L"I could not open the raw hex output file \"%s\" for writing!\n", Arg);
+						Success = FALSE;
+						break;
+					}
+				}
+				else {
+					GenHex = TRUE;
+				}
+			}
+			else {
+				wprintf(L"Option --rawhex was provided twice!\n");
+				Success = FALSE;
+				break;
+			}
+		}
+		else if (StartsWith(Arg, L"--symboltable")) {
+			if (Index + 1 >= ArgCount) { Arg = L""; }
+			else { Arg = Args[Index + 1]; }
+
+			if (OutSymbolTable == 0 && GenSymbolTable == FALSE) {
+				if (!((StartsWith(Arg, L"--")) || (Arg[0] == 0))) {
+					Index++;
+					OutSymbolTable = _wfopen(Arg, L"w,ccs=UNICODE");
+					if (OutSymbolTable == 0) {
+						wprintf(L"I could not open the symbol table output file \"%s\" for writing!\n", Arg);
+						Success = FALSE;
+						break;
+					}
+				}
+				else {
+					GenSymbolTable = TRUE;
+				}
+			}
+			else {
+				wprintf(L"Option --symboltable was provided twice!\n");
+				Success = FALSE;
+				break;
+			}
+		}
+		else if (StartsWith(Arg, L"--listing")) {
+			if (Index + 1 >= ArgCount) { Arg = L""; }
+			else { Arg = Args[Index + 1]; }
+
+			if (OutListing == 0 && GenListing == FALSE) {
+				if (!((StartsWith(Arg, L"--")) || (Arg[0] == 0))) {
+					Index++;
+					OutListing = _wfopen(Arg, L"w,ccs=UNICODE");
+					if (OutListing == 0) {
+						wprintf(L"I could not open the listing output file \"%s\" for writing!\n", Arg);
+						Success = FALSE;
+						break;
+					}
+				}
+				else {
+					GenListing = TRUE;
+				}
+			}
+			else {
+				wprintf(L"Option --listing was provided twice!\n");
+				Success = FALSE;
+				break;
+			}
+		}
+		else if (StartsWith(Arg, L"--")) {
+			wprintf(L"Unknown commandline operation encountered: \"%s\"\n", Arg);
+			printf(HelpMessage);
+			Success = FALSE;
+			break;
+		}
+		else if (InFile == 0) { // This must be our one input file.
+			InFile = _wfopen(Arg, L"rb");
+			if (InFile == 0) {
+				wprintf(L"I could not open the input file \"%s\" for reading!\n", Arg);
+				Success = FALSE;
+				break;
+			}
+			if (Success) {
+				InFileSize = Platform_GetFileSize(Arg, &Success);
+				InFileName = Arg;
+			}
+		}
+		else {
+			wprintf(L"Unknown commandline operation encountered: \"%s\"\n", Arg);
+			printf(HelpMessage);
+			Success = FALSE;
+			break;
+		}
+
+		Index++;
+	}
+
+	if (GenLogisim) {
+		// @TODO this block could be pulled out into a function.
+		int DotIndex = IndexOfFromEnd(InFileName, L'.');
+		int AutoFileNameLength = DotIndex + wcslen(L".LogisimImage") + 1;
+		wchar_t *AutoFileName = calloc(AutoFileNameLength, sizeof(wchar_t));
+		_snwprintf(AutoFileName, AutoFileNameLength, L"%.*s.LogisimImage", DotIndex, InFileName);
+
+		OutLogisim = _wfopen(AutoFileName, L"w");
+		if (OutLogisim == 0) {
+			wprintf(L"I could not open the Logisim output file's auto-generated path \"%s\" for writing!\n", AutoFileName);
+			Success = FALSE;
+		}
+		free(AutoFileName);
+	}
+	if (GenHex) {
+		int DotIndex = IndexOfFromEnd(InFileName, L'.');
+		int AutoFileNameLength = DotIndex + wcslen(L".hex") + 1;
+		wchar_t *AutoFileName = calloc(AutoFileNameLength, sizeof(wchar_t));
+		_snwprintf(AutoFileName, AutoFileNameLength, L"%.*s.hex", DotIndex, InFileName);
+
+		OutHex = _wfopen(AutoFileName, L"wb");
+		if (OutLogisim == 0) {
+			wprintf(L"I could not open the raw hex output file's auto-generated path \"%s\" for writing!\n", AutoFileName);
+			Success = FALSE;
+		}
+		free(AutoFileName);
+	}
+	if (GenListing) {
+		int DotIndex = IndexOfFromEnd(InFileName, L'.');
+		int AutoFileNameLength = DotIndex + wcslen(L".lst") + 1;
+		wchar_t *AutoFileName = calloc(AutoFileNameLength, sizeof(wchar_t));
+		_snwprintf(AutoFileName, AutoFileNameLength, L"%.*s.lst", DotIndex, InFileName);
+
+		OutListing = _wfopen(AutoFileName, L"w,ccs=UNICODE");
+		if (OutLogisim == 0) {
+			wprintf(L"I could not open the listing output file's auto-generated path \"%s\" for writing!\n", AutoFileName);
+			Success = FALSE;
+		}
+		free(AutoFileName);
+	}
+	if (GenSymbolTable) {
+		int DotIndex = IndexOfFromEnd(InFileName, L'.');
+		int AutoFileNameLength = DotIndex + wcslen(L".sym") + 1;
+		wchar_t *AutoFileName = calloc(AutoFileNameLength, sizeof(wchar_t));
+		_snwprintf(AutoFileName, AutoFileNameLength, L"%.*s.sym", DotIndex, InFileName);
+
+		OutSymbolTable = _wfopen(AutoFileName, L"w,ccs=UNICODE");
+		if (OutLogisim == 0) {
+			wprintf(L"I could not open the Logisim output file's auto-generated path \"%s\" for writing!\n", AutoFileName);
+			Success = FALSE;
+		}
+		free(AutoFileName);
+	}
+
+	if (Success) {
+		Success = ApplicationMain(InFile, InFileSize, OutLogisim, OutHex, OutSymbolTable, OutListing);
+	}
+	else {
+		printf("Exiting without invoking the assembler.\n");
+	}
+
+	return Success;
 }


### PR DESCRIPTION
This pull request changes the way the user receives output files from the assembler.

Instead of getting all 4 outputs at the same time, either with a provided name, or an auto-generated name, the user must now op-in to each output type they wish to get.

The input file is specified as a path which does not belong to another option.
The output files are opted-in as follow. for each option the [FilePath] parameter is optional. If it is not provided, then the assembler will auto generate a path based on the input file's name.
```
--logisim [FileName] ==> Outputs Logisim rom image at [FileName], or if blank <InFileName>.LogisimImage
--rawhex [FileName] ==> Outputs a file containing the raw hex for the program at [FileName], or if blank <InFileName>.hex
--symboltable [FileName] ==> Outputs a file containing a symbol table for the program at [FileName], or if blank <InFileName>.sym
--listing [FileName] ==> Outputs a file containing a listing for the program at [FileName], or if blank <InFileName>.lst
```

Under the hood, the core program no longer knows about any paths. Instead, it is given `FILE*` file streams which the core program reads, writes, and closes them.